### PR TITLE
fix multiple registry values

### DIFF
--- a/sxs.py
+++ b/sxs.py
@@ -36,8 +36,8 @@ class Update:
     def generate_component_manifest(self):
         registry_entries = []
         if self.registry_keys:
-            registry_values = []
             for registry_key in self.registry_keys:
+                registry_values = []
                 for registry_value in registry_key['values']:
                     registry_values.append(f"""<registryValue name="{registry_value['key']}" valueType="{registry_value['type']}" value="{registry_value['value']}" />""")
                 registry_values = '\n'.join(registry_values)


### PR DESCRIPTION
### before
![cmd_eV6aR4ixyJ](https://github.com/echnobas/sxsc/assets/65787561/96c3fff4-4763-48d9-8a9b-6ca8bd4fa825)

### config used to test
```yaml
copyright: Echnobas (c)
package: Echnobas-CommonSense-Antivirus-Package
target_arch: amd64
version: 1.0.0.3
updates:
  - target_component: Windows-Defender-Service
    target_arch: amd64
    version: 420.69.0.0
    registry_keys:
      - key_name: >-
          HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender Security Center\Notifications
        perUserVirtualization: false
        values:
          - key: DisableNotifications
            type: REG_DWORD
            value: 1
      - key_name: >-
          HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender Security Center\test
        perUserVirtualization: false
        values:
          - key: test
            type: REG_DWORD
            value: 1
```